### PR TITLE
Merge deprecation notices

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,9 @@
 > Concatenate files in the order you `require`.
 
 ## Archive Notice
-Although grunt is still alive and kicking some changes over the years have removed the need for this library:
+Although grunt is still alive as a task runner, changes over the years have removed the need for this library:
 
-* People generally have moved to gulp, webpack, or other tools
+* People generally have moved to gulp, webpack, or other tools for package building.
 * While `require` is still used heavily, the future is clearly `import`.
 
 This repo and published npm package remain for older projects, but this repo is archived. 

--- a/README.md
+++ b/README.md
@@ -3,6 +3,14 @@
 
 > Concatenate files in the order you `require`.
 
+## Archive Notice
+Although grunt is still alive and kicking some changes over the years have removed the need for this library:
+
+* People generally have moved to gulp, webpack, or other tools
+* While `require` is still used heavily, the future is clearly `import`.
+
+This repo and published npm package remain for older projects, but this repo is archived. 
+
 ## Getting Started
 If you haven't used [grunt][] before, be sure to check out the [Getting Started][] guide, as it explains how to create a [gruntfile][Getting Started] as well as install and use grunt plugins. Once you're familiar with that process, install this plugin with this command:
 


### PR DESCRIPTION
Update to upstream.

I'm choosing to keep our fork. It's unlikely that https://github.com/trek/grunt-neuter will be
removed, but it could happen. If it did, then we'd be unable to build our application.

Keeping our fork ensures we can build our code regardless of whether upstream gets removed.